### PR TITLE
[DEV APPROVED] New view to add cost calculator tool via CMS

### DIFF
--- a/lib/mastalk/snippets/tool.html.erb
+++ b/lib/mastalk/snippets/tool.html.erb
@@ -1,4 +1,4 @@
-# $~tool_embed, ~$
+# $~cost-calc, ~$
 
 <div class="l-container-tool">
   <iframe id="calculator_embed"

--- a/lib/mastalk/snippets/tool.html.erb
+++ b/lib/mastalk/snippets/tool.html.erb
@@ -4,6 +4,7 @@
   <iframe id="calculator_embed"
 		  frameborder="0"
 		  width="100%"
+		  height="1000px"
 		  class="calculator-preview__iframe"
 		  src="https://www.moneyadviceservice.org.uk/en/cost-calculator-builder/embed/calculators/<%= Mastalk::Document.new(body.strip).to_html.gsub(/<br \/>|<p>|<\/p>|\n/, '') %>">
   </iframe>

--- a/lib/mastalk/snippets/tool.html.erb
+++ b/lib/mastalk/snippets/tool.html.erb
@@ -1,0 +1,11 @@
+# $~tool_embed, ~$
+
+<div class="l-container-tool">
+  <iframe id="calculator_embed"
+		  frameborder="0"
+		  width="100%"
+		  class="calculator-preview__iframe"
+		  src="https://www.moneyadviceservice.org.uk/en/cost-calculator-builder/embed/calculators/<%= Mastalk::Document.new(body.strip).to_html.gsub(/<br \/>|<p>|<\/p>|\n/, '') %>">
+  </iframe>
+  <script src="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/cost_calculator_builder/embed-06ce0df8c79534fead5871af5a3875bd.js"></script>
+</div>

--- a/spec/mastalk_spec.rb
+++ b/spec/mastalk_spec.rb
@@ -150,6 +150,14 @@ describe Mastalk::Document do
     end
   end
 
+  context 'cost calculator' do
+    let(:source) {"$~cost-calc1~$"}
+
+    it 'pre-processes correctly' do
+      expect(subject.to_html).to include('https://www.moneyadviceservice.org.uk/en/cost-calculator-builder/embed/calculators/1')
+    end
+  end
+
   context 'when youtube video' do
     let(:source) { '({oZ0_U108aZw})' }
 


### PR DESCRIPTION
Allow editor to add cost calculator tool to pages via CMS

Relates to https://github.com/moneyadviceservice/cms/pull/282