### PR TITLE
[DEV APPROVED] Preventing related videos from displaying

### DIFF
--- a/lib/mastalk/snippets/video.html.erb
+++ b/lib/mastalk/snippets/video.html.erb
@@ -4,6 +4,6 @@
   frameborder="0"
   height="413"
   width="680"
-  src= "<%= "https://www.youtube.com/embed/#{body}" %>"
+  src= "<%= "https://www.youtube.com/embed/#{body}?rel=0" %>"
   title="Video">
 </iframe>

--- a/spec/mastalk_spec.rb
+++ b/spec/mastalk_spec.rb
@@ -162,7 +162,7 @@ describe Mastalk::Document do
     let(:source) { '({oZ0_U108aZw})' }
 
     it 'outputs the youtube embed video' do
-      expect(subject.to_html).to include('https://www.youtube.com/embed/oZ0_U108aZw')
+      expect(subject.to_html).to include('https://www.youtube.com/embed/oZ0_U108aZw?rel=0')
     end
   end
 


### PR DESCRIPTION
At the end of youtube videos on MAS site, a list of suggested videos
are offered some based on relation to the video and on occasion based
on user browsing history.  This prevents the related videos from
displaying