### PR TITLE
Adding default width & height - Brightcove

### DIFF
--- a/lib/mastalk/snippets/bright_video.html.erb
+++ b/lib/mastalk/snippets/bright_video.html.erb
@@ -6,6 +6,7 @@
           allowfullscreen=""
           webkitallowfullscreen=""
           mozallowfullscreen=""
-          style="width: 100%; height: 100%; position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;" >
+          height="413"
+          width="680">
   </iframe>
 </div>


### PR DESCRIPTION
Adding default dimensions to bright cove videos, the inline css
supplied in the embed code causes issues on partner sites
(http://www.nidirect.gov.uk/index/information-and-services/money-tax-and
-benefits/managing-money/bank_accounts/how-to-choose-the-right-bank-acco
unt.htm)

This solution sets a default height and width which mimic’s the youtube
snippet settings.  These get overwritten by our frontend .video-wrapper
element so has no effect on our user experience