### PR TITLE
Bump mastalk gem version to 0.5.8

### DIFF
--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.5.7'
+  s.version     = '0.5.8'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']


### PR DESCRIPTION
Bumping mastalk version for the brightcove default width and height update, fixed dimensions wont apply to frontend as we have css to handle the responsive size, the issue was for partners using webfeeds