### PR TITLE
[DEV APPROVED] Replace Rack CDN with Azure CDN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: ruby
 rvm:
   - 2.1.2
   - 1.9.3
+before_install:
+  - gem install bundler

--- a/lib/mastalk/snippets/tool.html.erb
+++ b/lib/mastalk/snippets/tool.html.erb
@@ -8,5 +8,5 @@
 		  class="calculator-preview__iframe"
 		  src="https://www.moneyadviceservice.org.uk/en/cost-calculator-builder/embed/calculators/<%= Mastalk::Document.new(body.strip).to_html.gsub(/<br \/>|<p>|<\/p>|\n/, '') %>">
   </iframe>
-  <script src="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/cost_calculator_builder/embed-06ce0df8c79534fead5871af5a3875bd.js"></script>
+  <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/cost_calculator_builder/embed-06ce0df8c79534fead5871af5a3875bd.js"></script>
 </div>


### PR DESCRIPTION
Replacing the rackspace cdn url for the new Azure CDN, in this instance
the CDN is used when an editor adds a cost calculator tool to an
article using the CMS