### PR TITLE
[DEV APPROVED] Updating Mastalk Version to 0.5.9

### DIFF
--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.5.8'
+  s.version     = '0.5.9'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']


### PR DESCRIPTION
Updating the version of mastalk for the azure migration, new gem 0.5.9 pushed to RubyGems.

New version contains the following PR: https://github.com/moneyadviceservice/mastalk/pull/17