### PR TITLE
[DEV APPROVED] Tells kramdown gem to not auto-generate ID attributes on headings

### DIFF
--- a/lib/mastalk.rb
+++ b/lib/mastalk.rb
@@ -14,14 +14,16 @@ module Mastalk
       @source = source.dup
     end
 
-    def to_html
-      ::HTMLEntities.new.decode( kramdown.to_html )
+    def to_html(options = {})
+      options[:auto_id] = options[:auto_id].nil? ? true : options[:auto_id]
+      ::HTMLEntities.new.decode( kramdown(options).to_html() )
     end
 
     private
 
-    def kramdown
-      Kramdown::Document.new(preprocess(source))
+    def kramdown(options = {})
+      options[:auto_id] = options[:auto_id].nil? ? true : options[:auto_id]
+      Kramdown::Document.new(preprocess(source), :auto_ids => options[:auto_id])
     end
 
     def preprocess(source)

--- a/lib/mastalk/snippets/callout.html.erb
+++ b/lib/mastalk/snippets/callout.html.erb
@@ -1,5 +1,5 @@
 # $~callout, ~$
 
 <div class='callout'>
-  <%= Mastalk::Document.new(body.strip).to_html %>
+  <%= Mastalk::Document.new(body.strip).to_html(:auto_id => false) %>
 </div>

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.6.0'
+  s.version     = '0.7.0'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/spec/mastalk_spec.rb
+++ b/spec/mastalk_spec.rb
@@ -12,6 +12,10 @@ describe Mastalk::Document do
       expect(Mastalk::Document.new('test').to_html).to eq("<p>test</p>\n")
     end
 
+    it 'generates automatic ID attributes on headings' do
+      expect(Mastalk::Document.new('##test').to_html).to eq(%Q(<h2 id="test">test</h2>\n))
+    end
+
     it 'converts to html' do
       expect(subject.to_html).to eq(expected)
     end
@@ -98,10 +102,10 @@ describe Mastalk::Document do
     let(:source) { "$~callout\n ##yes ~$ $~callout\n ##yes ~$" }
 
     let(:expected) do
-      "<div class=\"callout\">\n  <h2 id=\"yes\">yes</h2>\n\n</div>\n<div class=\"callout\">\n  <h2 id=\"yes\">yes</h2>\n\n</div>\n"
+      %Q(<div class="callout">\n  <h2>yes</h2>\n\n</div>\n<div class="callout">\n  <h2>yes</h2>\n\n</div>\n)
     end
 
-    it 'pre-processes correctly' do
+    it 'pre-processes correctly, without adding ids to headings' do
       expect(subject.to_html).to eq(expected)
     end
   end


### PR DESCRIPTION
When Mastalk converts the markdown for each article into HTML, it adds an 'ID' attribute to every `<h1>, <h2>, <h3>` etc. These IDs can be useful, particularly when providing in-page links of the `/#the-id` format. However, this feature is causing problems if the same heading text is repeated on the page - you get duplicate IDs, and therefore invalid HTML.

This is only an issue on the MAS site for the 'callout' module within the CMS, as this is commonly reused on the page - e.g. if something generic is used such as '_Top Tip_' or '_Did You Know_' - we get duplicate IDs.

Auto-ID generation is a fairly standard feature of markdown so this PR configures the `kramdown` gem not to use it for the callout module.

For reference, this is the callout module that appears across MAS articles:
![image](https://cloud.githubusercontent.com/assets/14920201/19033814/5366c372-8958-11e6-8dac-ffb266db8fb6.png)

