### PR TITLE
[DEV APPROVED] 7757 - New callout tool snippet

### DIFF
--- a/lib/mastalk/snippets/callout.html.erb
+++ b/lib/mastalk/snippets/callout.html.erb
@@ -1,5 +1,6 @@
 # $~callout, ~$
 
 <div class='callout'>
+  <span class="callout__icon" aria-hidden="true">?</span>
   <%= Mastalk::Document.new(body.strip).to_html(:auto_id => false) %>
 </div>

--- a/lib/mastalk/snippets/callout_tool.html.erb
+++ b/lib/mastalk/snippets/callout_tool.html.erb
@@ -1,0 +1,5 @@
+# $~tool-callout, ~$
+
+<div class='callout callout--tool'>
+  <%= Mastalk::Document.new(body.strip).to_html(:auto_id => false) %>
+</div>

--- a/lib/mastalk/snippets/callout_tool.html.erb
+++ b/lib/mastalk/snippets/callout_tool.html.erb
@@ -1,5 +1,10 @@
 # $~tool-callout, ~$
 
 <div class='callout callout--tool'>
+  <span class="callout__icon">
+    <svg class="callout__tool-icon" role="presentation" viewBox="0 0 100 100">
+      <use xlink:href="#svg-icon--tool"></use>
+    </svg>
+  </span>
   <%= Mastalk::Document.new(body.strip).to_html(:auto_id => false) %>
 </div>

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.7.0'
+  s.version     = '0.8.0'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/spec/mastalk_spec.rb
+++ b/spec/mastalk_spec.rb
@@ -102,7 +102,7 @@ describe Mastalk::Document do
     let(:source) { "$~callout\n ##yes ~$ $~callout\n ##yes ~$" }
 
     let(:expected) do
-      %Q(<div class="callout">\n  <h2>yes</h2>\n\n</div>\n<div class="callout">\n  <h2>yes</h2>\n\n</div>\n)
+      %Q(<div class="callout">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n<div class="callout">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n)
     end
 
     it 'pre-processes correctly, without adding ids to headings' do


### PR DESCRIPTION
## Overview
See [this PR](https://github.com/moneyadviceservice/cms/pull/363) for full explanation of the changes.

## Specifics
This PR adds a new snippet to MASTalk which is very similar to the 'Callout' snippet we already have, but is specifically for the 'Tools Callout'. The markup for this needs different classes and an icon to the standard Callout.

