### PR TITLE
[DEV APPROVED] Additional CSS classes for Callout

### DIFF
--- a/lib/mastalk/snippets/callout.html.erb
+++ b/lib/mastalk/snippets/callout.html.erb
@@ -1,6 +1,6 @@
 # $~callout, ~$
 
-<div class='callout'>
+<div class='callout callout--editorial callout--tip'>
   <span class="callout__icon" aria-hidden="true">?</span>
   <%= Mastalk::Document.new(body.strip).to_html(:auto_id => false) %>
 </div>

--- a/lib/mastalk/snippets/callout.html.erb
+++ b/lib/mastalk/snippets/callout.html.erb
@@ -1,6 +1,6 @@
 # $~callout, ~$
 
-<div class='callout callout--editorial callout--tip'>
+<div class='callout callout--tip'>
   <span class="callout__icon" aria-hidden="true">?</span>
   <%= Mastalk::Document.new(body.strip).to_html(:auto_id => false) %>
 </div>

--- a/lib/mastalk/snippets/callout_tool.html.erb
+++ b/lib/mastalk/snippets/callout_tool.html.erb
@@ -1,6 +1,6 @@
 # $~tool-callout, ~$
 
-<div class='callout callout--tool'>
+<div class='callout callout--editorial callout--tool'>
   <span class="callout__icon">
     <svg class="callout__tool-icon" role="presentation" viewBox="0 0 100 100">
       <use xlink:href="#svg-icon--tool"></use>

--- a/lib/mastalk/snippets/callout_tool.html.erb
+++ b/lib/mastalk/snippets/callout_tool.html.erb
@@ -1,6 +1,6 @@
 # $~tool-callout, ~$
 
-<div class='callout callout--editorial callout--tool'>
+<div class='callout callout--tool'>
   <span class="callout__icon">
     <svg class="callout__tool-icon" role="presentation" viewBox="0 0 100 100">
       <use xlink:href="#svg-icon--tool"></use>

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.8.0'
+  s.version     = '0.8.1'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/spec/mastalk_spec.rb
+++ b/spec/mastalk_spec.rb
@@ -102,7 +102,7 @@ describe Mastalk::Document do
     let(:source) { "$~callout\n ##yes ~$ $~callout\n ##yes ~$" }
 
     let(:expected) do
-      %Q(<div class="callout callout--editorial callout--tip">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n<div class="callout callout--editorial callout--tip">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n)
+      %Q(<div class="callout callout--tip">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n<div class="callout callout--tip">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n)
     end
 
     it 'pre-processes correctly, without adding ids to headings' do

--- a/spec/mastalk_spec.rb
+++ b/spec/mastalk_spec.rb
@@ -102,7 +102,7 @@ describe Mastalk::Document do
     let(:source) { "$~callout\n ##yes ~$ $~callout\n ##yes ~$" }
 
     let(:expected) do
-      %Q(<div class="callout">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n<div class="callout">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n)
+      %Q(<div class="callout callout--editorial callout--tip">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n<div class="callout callout--editorial callout--tip">\n  <span class="callout__icon" aria-hidden="true">?</span>\n  <h2>yes</h2>\n\n</div>\n)
     end
 
     it 'pre-processes correctly, without adding ids to headings' do


### PR DESCRIPTION
This PR adds some classes to the MASTalk snippet for the Callout module, that the refactored CSS will use