### PR TITLE
9106 - Adds fincap feedback UI component

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,30 @@ Outputs:
 
 `$bl_c` `$bl_m` positioning can be swapped around to switch element positions.
 
+### FinCap Feedback Component
+
+```
+$fincap_feedback
+  EMAIL@ADDRESS.com
+$
+```
+
+Outputs:
+
+```
+<div class="feedback-box">
+  <h3 class="feedback-box__title">
+    Give us your feedback or ask a question
+  </h3>
+  <svg xmlns="http://www.w3.org/2000/svg" class="feedback-box__icon svg-icon svg-icon--speech" focusable="false">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--speech"></use>
+  </svg>
+  <a href="mailto:EMAIL@ADDRESS.com" class="feedback-box__text">
+    EMAIL@ADDRESS.com
+  </a>
+</div>
+```
+
 ### Profiling Mastalk
 
 Inside of the project you can run:

--- a/lib/mastalk/snippets/feedback.html.erb
+++ b/lib/mastalk/snippets/feedback.html.erb
@@ -1,0 +1,13 @@
+# $fincap_feedback, $
+
+<div class="feedback-box">
+  <h3 class="feedback-box__title">
+    Give us your feedback or ask a question
+  </h3>
+  <svg xmlns="http://www.w3.org/2000/svg" class="feedback-box__icon svg-icon svg-icon--speech" focusable="false">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--speech"></use>
+  </svg>
+  <a href="mailto:<%= Mastalk::Document.new(body.strip).to_html.gsub(/<p>|<\/p>|\n/, '') %>" class="feedback-box__text">
+    <%= Mastalk::Document.new(body.strip).to_html.gsub(/<p>|<\/p>|\n/, '') %>
+  </a>
+</div>

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.9.0'
+  s.version     = '0.9.1'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/spec/mastalk/document_spec.rb
+++ b/spec/mastalk/document_spec.rb
@@ -283,4 +283,17 @@ describe Mastalk::Document do
       expect(subject.to_html).to eq(expected)
     end
   end
+
+  context 'Fincap Feedback UI Component' do
+    let(:email_address) { 'test@email.com' }
+    let(:source) { "$fincap_feedback#{email_address}$" }
+
+    let(:expected) do
+      %(<a href="mailto:#{email_address}" class="feedback-box__text">)
+    end
+
+    it 'outputs the correct mailto link' do
+      expect(subject.to_html).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
# 9106 - Adds fincap feedback UI component

TP Ticket [9106](https://moneyadviceservice.tpondemand.com/entity/9106-feedback-ui-component)

This PR adds the snippet and test for the FinCap feedback component, there also changes required to the CMS, [the associated PR can be found here](https://github.com/moneyadviceservice/cms/pull/420)

The snippet on the CMS side accepts and email address:

```
$fincap_feedback 
EMAIL@ADDRESS.COM 
$
```

Which is then inserted into the link text and mailto url:

| Screenshot |
|------------|
|![image](https://user-images.githubusercontent.com/13165846/38734190-8f150f70-3f1c-11e8-93c2-40b63b48c8be.png)|


