### PR TITLE
9128 primary button snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,22 @@ Outputs:
 </div>
 ```
 
+### FinCap Primary Button 
+
+```
+$~fincap_primary_button
+  [Link Text](LINK_URL)
+$
+```
+
+Outputs:
+
+```
+<span class="article__primary-button">
+  <a href="LINK_URL">Link Text</a>
+</span>
+```
+
 ### Profiling Mastalk
 
 Inside of the project you can run:

--- a/lib/mastalk/snippets/fincap_primary_button.html.erb
+++ b/lib/mastalk/snippets/fincap_primary_button.html.erb
@@ -1,0 +1,5 @@
+# $~fincap_primary_button, ~$
+
+<span class="article__primary-button">
+  <%= Mastalk::Document.new(body.strip).to_html.gsub(/<p>|<\/p>|\n/, '') %>
+</span>

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.9.1'
+  s.version     = '0.9.2'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/spec/mastalk/document_spec.rb
+++ b/spec/mastalk/document_spec.rb
@@ -296,4 +296,18 @@ describe Mastalk::Document do
       expect(subject.to_html).to include(expected)
     end
   end
+
+  context 'Fincap Primary Button' do
+    let(:link_text) { 'test text' }
+    let(:link_url) { 'https://www.moneyadviceservice.org.uk' }
+    let(:source) { "$~fincap_primary_button[#{link_text}](#{link_url})~$" }
+
+    let(:expected) do
+      %(<a href="#{link_url}">#{link_text}</a>)
+    end
+
+    it 'outputs the correct link url and text' do
+      expect(subject.to_html).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
# 9128 - primary button snippet

TP Ticket [9128](https://moneyadviceservice.tpondemand.com/entity/9128-primary-button-snippet)

This PR adds the snippet and test for the FinCap primary button to be inserted into articles from the CMS, there also changes required to the CMS, [the associated PR can be found here](https://github.com/moneyadviceservice/cms/pull/429)

The snippet on the CMS side accepts a URL and text:

```
$~fincap_primary_button 
[LINK_TEXT](LINK_URL) 
~$
```

Screenshot of frontend:

![image](https://user-images.githubusercontent.com/13165846/38992091-992261b0-43d7-11e8-81bc-3235124eb923.png)
