### PR TITLE
[DEV APPROVED] Fincap Specific Snippets (Feedback & Primary button)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,22 @@ Outputs:
 </div>
 ```
 
+### FinCap Primary Button 
+
+```
+$~fincap_primary_button
+  [Link Text](LINK_URL)
+$
+```
+
+Outputs:
+
+```
+<span class="article__primary-button">
+  <a href="LINK_URL">Link Text</a>
+</span>
+```
+
 ### Profiling Mastalk
 
 Inside of the project you can run:

--- a/README.md
+++ b/README.md
@@ -365,6 +365,30 @@ Outputs:
 
 `$bl_c` `$bl_m` positioning can be swapped around to switch element positions.
 
+### FinCap Feedback Component
+
+```
+$fincap_feedback
+  EMAIL@ADDRESS.com
+$
+```
+
+Outputs:
+
+```
+<div class="feedback-box">
+  <h3 class="feedback-box__title">
+    Give us your feedback or ask a question
+  </h3>
+  <svg xmlns="http://www.w3.org/2000/svg" class="feedback-box__icon svg-icon svg-icon--speech" focusable="false">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--speech"></use>
+  </svg>
+  <a href="mailto:EMAIL@ADDRESS.com" class="feedback-box__text">
+    EMAIL@ADDRESS.com
+  </a>
+</div>
+```
+
 ### Profiling Mastalk
 
 Inside of the project you can run:

--- a/lib/mastalk/snippets/feedback.html.erb
+++ b/lib/mastalk/snippets/feedback.html.erb
@@ -1,0 +1,13 @@
+# $fincap_feedback, $
+
+<div class="feedback-box">
+  <h3 class="feedback-box__title">
+    Give us your feedback or ask a question
+  </h3>
+  <svg xmlns="http://www.w3.org/2000/svg" class="feedback-box__icon svg-icon svg-icon--speech" focusable="false">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--speech"></use>
+  </svg>
+  <a href="mailto:<%= Mastalk::Document.new(body.strip).to_html.gsub(/<p>|<\/p>|\n/, '') %>" class="feedback-box__text">
+    <%= Mastalk::Document.new(body.strip).to_html.gsub(/<p>|<\/p>|\n/, '') %>
+  </a>
+</div>

--- a/lib/mastalk/snippets/fincap_primary_button.html.erb
+++ b/lib/mastalk/snippets/fincap_primary_button.html.erb
@@ -1,0 +1,5 @@
+# $~fincap_primary_button, ~$
+
+<span class="article__primary-button">
+  <%= Mastalk::Document.new(body.strip).to_html.gsub(/<p>|<\/p>|\n/, '') %>
+</span>

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.9.2'
+  s.version     = '0.9.1'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.9.1'
+  s.version     = '0.9.2'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/mastalk.gemspec
+++ b/mastalk.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'mastalk'
-  s.version     = '0.9.0'
+  s.version     = '0.9.1'
   s.summary     = 'mastalk'
   s.description = 'Mastalk markdown extension language'
   s.authors     = ['Douglas Roper', 'Justin Perry']

--- a/spec/mastalk/document_spec.rb
+++ b/spec/mastalk/document_spec.rb
@@ -283,4 +283,17 @@ describe Mastalk::Document do
       expect(subject.to_html).to eq(expected)
     end
   end
+
+  context 'Fincap Feedback UI Component' do
+    let(:email_address) { 'test@email.com' }
+    let(:source) { "$fincap_feedback#{email_address}$" }
+
+    let(:expected) do
+      %(<a href="mailto:#{email_address}" class="feedback-box__text">)
+    end
+
+    it 'outputs the correct mailto link' do
+      expect(subject.to_html).to include(expected)
+    end
+  end
 end

--- a/spec/mastalk/document_spec.rb
+++ b/spec/mastalk/document_spec.rb
@@ -296,4 +296,18 @@ describe Mastalk::Document do
       expect(subject.to_html).to include(expected)
     end
   end
+
+  context 'Fincap Primary Button' do
+    let(:link_text) { 'test text' }
+    let(:link_url) { 'https://www.moneyadviceservice.org.uk' }
+    let(:source) { "$~fincap_primary_button[#{link_text}](#{link_url})~$" }
+
+    let(:expected) do
+      %(<a href="#{link_url}">#{link_text}</a>)
+    end
+
+    it 'outputs the correct link url and text' do
+      expect(subject.to_html).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
## Please Read

This branch was created for the testing and deployment of the fincap specific snippets in mastalk.  These are specifically the Primary button ([TP9128](https://moneyadviceservice.tpondemand.com/entity/9128-primary-button-snippet)) and the feedback component ([TP9106](https://moneyadviceservice.tpondemand.com/entity/9106-feedback-ui-component)).

It has been noticed that the MAS CMS master branch is referencing this branch rather than the latest version of mastalk. ([Please see CMS repo gem file](https://github.com/moneyadviceservice/cms/blob/ea12ac40ffb9671a9cd7d72e7bba86fff0ff4473/Gemfile#L27)).

The CMS should not be referencing the fincap branch on mastalk directly, these changes should be merged in and the CMS should reference the latest version.